### PR TITLE
P2-14: Add Django Channels + Supabase Realtime

### DIFF
--- a/backend/django/apps/reviews/services/orchestrator.py
+++ b/backend/django/apps/reviews/services/orchestrator.py
@@ -11,6 +11,7 @@ from typing import Any
 import httpx
 from django.conf import settings
 from django.db import transaction
+from django.utils import timezone
 
 from apps.reviews.models import Review, ReviewComment, ReviewRun
 
@@ -80,6 +81,8 @@ class ReviewOrchestrator:
 
         self.review.status = "processing"
         self.review.save(update_fields=["status"])
+        self._push_status_to_channels("processing")
+        self._push_status_to_supabase("processing")
 
         try:
             diff = self._fetch_diff()
@@ -95,6 +98,12 @@ class ReviewOrchestrator:
                 update_fields=["status", "risk_score", "summary", "completed_at"]
             )
 
+            self._push_status_to_channels(
+                "completed",
+                {"summary": self.review.summary, "risk_score": self.review.risk_score},
+            )
+            self._push_status_to_supabase("completed")
+
             self._trigger_github_post()
 
             self._produce_kafka_event()
@@ -105,6 +114,8 @@ class ReviewOrchestrator:
             self.review.status = "failed"
             self.review.summary = f"Error: {str(exc)[:500]}"
             self.review.save(update_fields=["status", "summary"])
+            self._push_status_to_channels("failed", {"error": str(exc)[:200]})
+            self._push_status_to_supabase("failed")
             raise
 
     def _fetch_diff(self) -> str:
@@ -254,6 +265,84 @@ class ReviewOrchestrator:
         except Exception as e:
             logger.error(
                 "orchestrator.kafka_event_failed review_id=%d error=%s",
+                self.review.pk,
+                str(e),
+            )
+
+    def _push_status_to_channels(self, status: str, extra: dict | None = None) -> None:
+        """Push status update to WebSocket channels."""
+        try:
+            import asyncio
+            from asgiref.sync import async_to_sync
+            from channels.layers import get_channel_layer
+
+            channel_layer = get_channel_layer()
+            group_name = f"review_{self.review.pk}"
+
+            message = {
+                "review_id": self.review.pk,
+                "status": status,
+            }
+            if extra:
+                message.update(extra)
+
+            async def _send():
+                await channel_layer.group_send(group_name, message)
+
+            async_to_sync(_send)()
+            logger.info(
+                "orchestrator.channel_pushed review_id=%d status=%s",
+                self.review.pk,
+                status,
+            )
+        except Exception as e:
+            logger.error(
+                "orchestrator.channel_push_failed review_id=%d error=%s",
+                self.review.pk,
+                str(e),
+            )
+
+    def _push_status_to_supabase(self, status: str) -> None:
+        """Insert status update into Supabase review_status_updates table."""
+        supabase_url = getattr(settings, "SUPABASE_URL", None)
+        supabase_key = getattr(settings, "SUPABASE_SERVICE_KEY", None)
+
+        if not supabase_url or not supabase_key:
+            logger.warning("Supabase not configured, skipping status push")
+            return
+
+        try:
+            import asyncio
+            from asgiref.sync import async_to_sync
+
+            async def _insert():
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    await client.post(
+                        f"{supabase_url}/rest/v1/review_status_updates",
+                        json={
+                            "review_id": self.review.pk,
+                            "status": status,
+                            "summary": self.review.summary or "",
+                            "risk_score": self.review.risk_score or 0,
+                            "updated_at": timezone.now().isoformat(),
+                        },
+                        headers={
+                            "apikey": supabase_key,
+                            "Authorization": f"Bearer {supabase_key}",
+                            "Content-Type": "application/json",
+                            "Prefer": "return=minimal",
+                        },
+                    )
+
+            async_to_sync(_insert)()
+            logger.info(
+                "orchestrator.supabase_pushed review_id=%d status=%s",
+                self.review.pk,
+                status,
+            )
+        except Exception as e:
+            logger.error(
+                "orchestrator.supabase_push_failed review_id=%d error=%s",
                 self.review.pk,
                 str(e),
             )

--- a/backend/django/realtime/__init__.py
+++ b/backend/django/realtime/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "realtime.apps.RealtimeConfig"

--- a/backend/django/realtime/apps.py
+++ b/backend/django/realtime/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class RealtimeConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "realtime"
+    verbose_name = "Realtime"
+
+    def ready(self):
+        pass

--- a/backend/django/realtime/consumers.py
+++ b/backend/django/realtime/consumers.py
@@ -1,0 +1,106 @@
+import json
+import logging
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
+from django.conf import settings
+
+from .events import ReviewEventType, get_review_group
+
+logger = logging.getLogger(__name__)
+
+
+class ReviewStatusConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.review_id = self.scope["url_route"]["kwargs"].get("review_id")
+        self.user = self.scope.get("user")
+
+        if not self.user or not self.user.is_authenticated:
+            await self.close(code=4003)
+            return
+
+        self.group_name = get_review_group(self.review_id)
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+        logger.info(
+            f"WebSocket connected: review={self.review_id}, user={self.user.id}"
+        )
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+            logger.info(f"WebSocket disconnected: review={self.review_id}")
+
+    async def receive(self, text_data):
+        pass
+
+    async def review_status_update(self, event):
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": ReviewEventType.STATUS_CHANGED,
+                    "review_id": event["review_id"],
+                    "status": event["status"],
+                    "message": event.get("message", ""),
+                }
+            )
+        )
+
+    async def review_completed(self, event):
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": ReviewEventType.COMPLETED,
+                    "review_id": event["review_id"],
+                    "status": event["status"],
+                    "summary": event.get("summary", {}),
+                }
+            )
+        )
+
+    async def review_failed(self, event):
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": ReviewEventType.FAILED,
+                    "review_id": event["review_id"],
+                    "status": event["status"],
+                    "error": event.get("error", ""),
+                }
+            )
+        )
+
+
+class NotificationConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.user = self.scope.get("user")
+
+        if not self.user or not self.user.is_authenticated:
+            await self.close(code=4003)
+            return
+
+        self.group_name = f"notifications_{self.user.id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+        logger.info(f"WebSocket connected: notifications for user={self.user.id}")
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        pass
+
+    async def notification_new(self, event):
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "notification.new",
+                    "notification_id": event["notification_id"],
+                    "title": event.get("title", ""),
+                    "message": event.get("message", ""),
+                }
+            )
+        )

--- a/backend/django/realtime/events.py
+++ b/backend/django/realtime/events.py
@@ -1,0 +1,19 @@
+class ReviewEventType:
+    STATUS_CHANGED = "review.status_changed"
+    COMPLETED = "review.completed"
+    FAILED = "review.failed"
+    PROGRESS = "review.progress"
+
+
+class NotificationEventType:
+    NEW = "notification.new"
+    READ = "notification.read"
+    DELETED = "notification.deleted"
+
+
+def get_review_group(review_id: int) -> str:
+    return f"review_{review_id}"
+
+
+def get_user_notifications_group(user_id: int) -> str:
+    return f"notifications_{user_id}"

--- a/backend/django/realtime/routing.py
+++ b/backend/django/realtime/routing.py
@@ -1,0 +1,10 @@
+from django.urls import re_path
+
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(
+        r"ws/reviews/(?P<review_id>\d+)/$", consumers.ReviewStatusConsumer.as_asgi()
+    ),
+    re_path(r"ws/notifications/$", consumers.NotificationConsumer.as_asgi()),
+]

--- a/backend/django/realtime/tests/test_consumers.py
+++ b/backend/django/realtime/tests/test_consumers.py
@@ -1,0 +1,48 @@
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
+from channels.auth import AuthMiddlewareStack
+
+from realtime.routing import websocket_urlpatterns
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="testuser", email="test@example.com", password="testpass123"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+class TestReviewStatusConsumer:
+    async def test_connect_authenticated(self, user, client):
+        client.force_login(user)
+        application = AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        communicator = WebsocketCommunicator(application, "/ws/reviews/1/")
+        connected, subprotocol = await communicator.connect()
+        assert connected is True
+        await communicator.disconnect()
+
+    async def test_disconnect_cleanup(self, user, client):
+        client.force_login(user)
+        application = AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        communicator = WebsocketCommunicator(application, "/ws/reviews/1/")
+        await communicator.connect()
+        await communicator.disconnect()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestNotificationConsumer:
+    async def test_connect_authenticated(self, user, client):
+        client.force_login(user)
+        application = AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        communicator = WebsocketCommunicator(application, "/ws/notifications/")
+        connected, subprotocol = await communicator.connect()
+        assert connected is True
+        await communicator.disconnect()


### PR DESCRIPTION
- Add realtime app with ReviewStatusConsumer and NotificationConsumer WebSocket consumers
- Add channel layer push on status transitions (pending→processing→completed/failed)
- Add Supabase insert on status changes to review_status_updates table
- Add WebSocket routing at /ws/reviews/{id}/ and /ws/notifications/
- Add event types and helper functions for review groups
- Add WebSocket tests (require Docker DB to run)