### PR TITLE
P2-16: Add observability (Grafana + Sentry) and E2E testing

### DIFF
--- a/backend/django/apps/core/__init__.py
+++ b/backend/django/apps/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.core.apps.CoreConfig"

--- a/backend/django/apps/core/apps.py
+++ b/backend/django/apps/core/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.core"
+    verbose_name = "Core"

--- a/backend/django/apps/core/logging.py
+++ b/backend/django/apps/core/logging.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+from typing import Any
+
+import structlog
+
+from django.conf import settings
+
+
+def configure_logging() -> None:
+    """Configure structlog with JSON output for production."""
+
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    if settings.DEBUG:
+        processors.append(structlog.dev.ConsoleRenderer())
+    else:
+        processors.append(structlog.processors.JSONRenderer())
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(name: str) -> Any:
+    """Get a structured logger instance."""
+    return structlog.get_logger(name)

--- a/backend/django/apps/core/metrics.py
+++ b/backend/django/apps/core/metrics.py
@@ -1,0 +1,135 @@
+from prometheus_client import Counter, Histogram, Gauge
+
+review_requests_total = Counter(
+    "devmind_review_requests_total",
+    "Total number of review requests",
+    ["status"],
+)
+
+review_duration_seconds = Histogram(
+    "devmind_review_duration_seconds",
+    "Time taken to complete a review",
+    buckets=[1, 5, 10, 30, 60, 120, 300, 600],
+)
+
+llm_latency_seconds = Histogram(
+    "devmind_llm_latency_seconds",
+    "LLM API call latency",
+    ["provider", "model"],
+    buckets=[0.5, 1, 2, 5, 10, 30, 60],
+)
+
+llm_tokens_total = Counter(
+    "devmind_llm_tokens_total",
+    "Total tokens used across LLM calls",
+    ["provider", "model", "type"],
+)
+
+llm_requests_total = Counter(
+    "devmind_llm_requests_total",
+    "Total LLM API requests",
+    ["provider", "model", "status"],
+)
+
+celery_task_duration_seconds = Histogram(
+    "devmind_celery_task_duration_seconds",
+    "Celery task execution time",
+    ["task_name"],
+    buckets=[0.1, 0.5, 1, 5, 10, 30, 60],
+)
+
+celery_queue_depth = Gauge(
+    "devmind_celery_queue_depth",
+    "Number of pending tasks in Celery queue",
+    ["queue"],
+)
+
+active_reviews = Gauge(
+    "devmind_active_reviews",
+    "Number of reviews currently being processed",
+)
+
+reviews_by_status = Gauge(
+    "devmind_reviews_by_status",
+    "Number of reviews by status",
+    ["status"],
+)
+
+risk_score_distribution = Histogram(
+    "devmind_risk_score_distribution",
+    "Distribution of risk scores",
+    buckets=[0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+)
+
+github_comments_posted_total = Counter(
+    "devmind_github_comments_posted_total",
+    "Total comments posted to GitHub",
+    ["status"],
+)
+
+kafka_messages_produced_total = Counter(
+    "devmind_kafka_messages_produced_total",
+    "Total Kafka messages produced",
+    ["topic", "status"],
+)
+
+kafka_messages_consumed_total = Counter(
+    "devmind_kafka_messages_consumed_total",
+    "Total Kafka messages consumed",
+    ["topic", "status"],
+)
+
+error_count_total = Counter(
+    "devmind_error_count_total",
+    "Total number of errors",
+    ["service", "error_type"],
+)
+
+scan_requests_total = Counter(
+    "devmind_scan_requests_total",
+    "Total repository scan requests",
+    ["status"],
+)
+
+scan_duration_seconds = Histogram(
+    "devmind_scan_duration_seconds",
+    "Time taken to complete a repository scan",
+    buckets=[5, 10, 30, 60, 120, 300, 600, 1800],
+)
+
+scan_findings_total = Counter(
+    "devmind_scan_findings_total",
+    "Total security/quality findings from scans",
+    ["severity", "category"],
+)
+
+webhook_events_total = Counter(
+    "devmind_webhook_events_total",
+    "Total GitHub webhook events received",
+    ["event_type", "status"],
+)
+
+
+def record_llm_call(
+    provider: str, model: str, latency: float, tokens: int, success: bool
+):
+    status = "success" if success else "error"
+    llm_requests_total.labels(provider=provider, model=model, status=status).inc()
+    if success:
+        llm_latency_seconds.labels(provider=provider, model=model).observe(latency)
+        llm_tokens_total.labels(provider=provider, model=model, type="prompt").inc(
+            tokens // 2
+        )
+        llm_tokens_total.labels(provider=provider, model=model, type="completion").inc(
+            tokens // 2
+        )
+
+
+def record_review_complete(duration: float, risk_score: int):
+    review_duration_seconds.observe(duration)
+    risk_score_distribution.observe(risk_score)
+    active_reviews.dec()
+
+
+def record_celery_task(task_name: str, duration: float):
+    celery_task_duration_seconds.labels(task_name=task_name).observe(duration)

--- a/backend/django/devmind/settings/base.py
+++ b/backend/django/devmind/settings/base.py
@@ -44,6 +44,7 @@ LOCAL_APPS = [
     "apps.reviews",
     "apps.notifications",
     "apps.analytics",
+    "apps.core",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
@@ -58,6 +59,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "devmind.urls"

--- a/backend/django/devmind/urls.py
+++ b/backend/django/devmind/urls.py
@@ -57,4 +57,5 @@ urlpatterns: list[Any] = [
             ]
         ),
     ),
+    path("", include("django_prometheus.urls")),
 ]

--- a/backend/django/pyproject.toml
+++ b/backend/django/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "channels-redis>=4.2,<5.0",
     "daphne>=4.0,<5.0",
     "confluent-kafka>=2.14.0",
+    "django-prometheus>=2.3,<3.0",
+    "prometheus-client>=0.19,<1.0",
 ]
 
 [dependency-groups]

--- a/backend/django/tests/test_e2e.py
+++ b/backend/django/tests/test_e2e.py
@@ -1,0 +1,148 @@
+"""
+End-to-end integration test for the full review pipeline.
+
+Tests: webhook -> trigger_review_task -> orchestrator -> FastAPI -> GitHub poster
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from django.test import override_settings
+
+from apps.reviews.models import Review, ReviewComment, Repository
+from apps.reviews.services.orchestrator import ReviewOrchestrator
+
+
+@pytest.fixture
+def repository(db):
+    return Repository.objects.create(
+        name="test-repo",
+        full_name="testuser/test-repo",
+        owner=MagicMock(),
+        github_token="test_token",
+    )
+
+
+@pytest.fixture
+def review(db, repository):
+    return Review.objects.create(
+        repository=repository,
+        pr_number=1,
+        pr_title="Test PR",
+        head_sha="abc123",
+        status="pending",
+    )
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+@pytest.mark.django_db
+class TestReviewPipeline:
+    def test_full_pipeline_webhook_to_comments(self, repository, review):
+        """
+        Test the full pipeline:
+        1. Webhook triggers review creation
+        2. ReviewOrchestrator processes the review
+        3. FastAPI is called (mocked)
+        4. Results are saved
+        5. GitHub comments are posted (mocked)
+        """
+        with patch("apps.reviews.services.orchestrator.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "repo_full_name": "testuser/test-repo",
+                "pr_number": 1,
+                "comments": [
+                    {
+                        "file_path": "src/main.py",
+                        "line_number": 10,
+                        "category": "security",
+                        "severity": "warning",
+                        "body": "Consider using environment variables for sensitive data",
+                        "suggested_fix": None,
+                    },
+                    {
+                        "file_path": "src/utils.py",
+                        "line_number": 25,
+                        "category": "code_quality",
+                        "severity": "info",
+                        "body": "Function is too long (50 lines)",
+                        "suggested_fix": "Consider breaking into smaller functions",
+                    },
+                ],
+                "risk_score": 45,
+                "model_used": "gpt-4",
+                "provider": "openai",
+                "latency_ms": 2500,
+            }
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_response)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.return_value = mock_response
+
+            with patch(
+                "apps.reviews.services.orchestrator.GithubService"
+            ) as mock_github:
+                mock_github.return_value.get_pull_request_diff.return_value = (
+                    "diff content"
+                )
+
+                orchestrator = ReviewOrchestrator(review)
+                result = orchestrator.run()
+
+        review.refresh_from_db()
+        assert review.status == "completed"
+        assert review.risk_score == 45
+        assert review.summary is not None
+
+        comments = ReviewComment.objects.filter(review=review)
+        assert comments.count() == 2
+        assert comments.filter(file_path="src/main.py").exists()
+        assert comments.filter(file_path="src/utils.py").exists()
+
+    def test_review_status_transitions(self, repository, review):
+        """Test that review status transitions correctly."""
+        with patch("apps.reviews.services.orchestrator.httpx.Client"):
+            with patch("apps.reviews.services.orchestrator.GithubService"):
+                orchestrator = ReviewOrchestrator(review)
+
+                review.refresh_from_db()
+                assert review.status == "pending"
+
+                orchestrator.run()
+
+                review.refresh_from_db()
+                assert review.status == "completed"
+
+    def test_orchestrator_handles_fastapi_error(self, repository, review):
+        """Test that orchestrator handles FastAPI errors gracefully."""
+        with patch("apps.reviews.services.orchestrator.httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 503
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_response)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.return_value = mock_response
+
+            with patch("apps.reviews.services.orchestrator.GithubService"):
+                orchestrator = ReviewOrchestrator(review)
+
+                with pytest.raises(Exception):
+                    orchestrator.run()
+
+        review.refresh_from_db()
+        assert review.status == "failed"
+
+
+@pytest.mark.django_db
+class TestMetricsEndpoint:
+    def test_metrics_endpoint_returns_data(self, client):
+        """Test that /metrics endpoint returns Prometheus format."""
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert "devmind_" in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestSentryErrorCapture:
+    def test_sentry_captures_test_error(self, client):
+        """Test that Sentry captures errors from test view."""
+        response = client.get("/test-error/")
+        assert response.status_code == 500

--- a/backend/fastapi/core/metrics.py
+++ b/backend/fastapi/core/metrics.py
@@ -2,7 +2,13 @@
 Prometheus metrics for FastAPI services.
 """
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, Gauge
+
+rag_pipeline_duration_seconds = Histogram(
+    "rag_pipeline_duration_seconds",
+    "RAG pipeline duration in seconds",
+    buckets=[0.1, 0.5, 1, 2, 5, 10, 30, 60],
+)
 
 rag_pipeline_duration = Histogram(
     "rag_pipeline_duration_ms",
@@ -26,13 +32,44 @@ llm_provider_requests = Counter(
     ["provider"],
 )
 
+llm_latency_seconds = Histogram(
+    "llm_latency_seconds",
+    "LLM API call latency in seconds",
+    ["provider", "model"],
+    buckets=[0.5, 1, 2, 5, 10, 30, 60],
+)
+
+llm_tokens_total = Counter(
+    "llm_tokens_total",
+    "Total tokens used across LLM calls",
+    ["provider", "model", "type"],
+)
+
 review_requests_total = Counter(
     "review_requests_total",
     "Total review requests",
+    ["status"],
 )
 
 review_errors_total = Counter(
     "review_errors_total",
     "Review errors by type",
     ["error_type"],
+)
+
+scan_requests_total = Counter(
+    "scan_requests_total",
+    "Total repository scan requests",
+    ["status"],
+)
+
+scan_findings_total = Counter(
+    "scan_findings_total",
+    "Total security/quality findings from scans",
+    ["severity", "category"],
+)
+
+active_scans = Gauge(
+    "active_scans",
+    "Number of scans currently running",
 )

--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from core.config import get_settings
 from core.logging import configure_logging
@@ -10,6 +11,16 @@ from routers.embeddings import router as embeddings_router
 from routers.scan import router as scan_router
 
 settings = get_settings()
+
+
+if settings.sentry_dsn:
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        traces_sample_rate=0.1,
+    )
 
 
 @asynccontextmanager
@@ -32,6 +43,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+Instrumentator().instrument(app).expose(app)
 
 app.include_router(health_router)
 app.include_router(review_router)

--- a/backend/fastapi/pyproject.toml
+++ b/backend/fastapi/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langgraph>=0.2,<1.0",
     "tiktoken>=0.7,<1.0",
     "prometheus-client>=0.20,<1.0",
+    "prometheus-fastapi-instrumentator>=6.1,<7.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
- Add Django core app with Prometheus metrics (18 custom metrics)
- Add FastAPI metrics (RAG pipeline, scan, LLM latency)
- Add django-prometheus middleware for /metrics endpoint
- Add Sentry initialization to FastAPI main.py
- Add prometheus-fastapi-instrumentator for FastAPI metrics
- Add structlog JSON logging configuration
- Add E2E test for full review pipeline
- Add dependencies: django-prometheus, prometheus-fastapi-instrumentator