### PR TITLE
fix: resolve login, settings, scan, and review display issues

### DIFF
--- a/backend/django/devmind/asgi.py
+++ b/backend/django/devmind/asgi.py
@@ -2,20 +2,23 @@ import os
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
-from channels.security.websocket import AllowedOriginsOriginValidator
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "devmind.settings.production")
 
 django_asgi_app = get_asgi_application()
 
+from realtime.auth import JwtQueryAuthMiddleware
 from realtime.routing import websocket_urlpatterns
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
-        "websocket": AllowedOriginsOriginValidator(
-            AuthMiddlewareStack(URLRouter(websocket_urlpatterns))
+        "websocket": AllowedHostsOriginValidator(
+            AuthMiddlewareStack(
+                JwtQueryAuthMiddleware(URLRouter(websocket_urlpatterns))
+            )
         ),
     }
 )

--- a/backend/django/realtime/auth.py
+++ b/backend/django/realtime/auth.py
@@ -1,0 +1,60 @@
+import logging
+from urllib.parse import parse_qs
+
+from channels.db import database_sync_to_async
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import AccessToken
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+class JwtQueryAuthMiddleware:
+    """
+    Authenticate WebSocket connections via JWT token in the query string.
+
+    Reads ``?token=<access_token>`` from the WebSocket URL, validates it
+    with ``rest_framework_simplejwt``, and sets ``scope["user"]``.
+
+    Intended to wrap (run *after*) ``AuthMiddlewareStack`` so that
+    session-based auth is tried first and JWT overrides it when present.
+    """
+
+    def __init__(self, inner):
+        self.inner = inner
+
+    async def __call__(self, scope, receive, send):
+        query_string = scope.get("query_string", b"").decode("utf-8")
+        params = parse_qs(query_string)
+        token_str = params.get("token", [None])[0]
+
+        if token_str:
+            try:
+                token = AccessToken(token_str)
+                user_id = token.payload.get("user_id")
+                if user_id is not None:
+                    user = await self._get_user(user_id)
+                    if user and user.is_active:
+                        scope["user"] = user
+                        logger.debug(
+                            "JWT auth succeeded for user=%s (ws path=%s)",
+                            user.id,
+                            scope.get("path", ""),
+                        )
+            except TokenError as exc:
+                logger.warning("JWT auth failed: %s", exc)
+
+        return await self.inner(scope, receive, send)
+
+    async def _get_user(self, user_id: int):
+        try:
+            return await _get_user_async(user_id)
+        except User.DoesNotExist:
+            return None
+
+
+@database_sync_to_async
+def _get_user_async(user_id: int):
+    return User.objects.get(pk=user_id)

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -140,7 +140,7 @@ export default function Dashboard() {
                           </div>
                         </td>
                         <td className="px-6 py-6">
-                          <ReviewStatus initialStatus={review.status} />
+                          <ReviewStatus reviewId={review.id} initialStatus={review.status} />
                         </td>
                         <td className="px-6 py-6">
                           <div className="flex justify-center">

--- a/frontend/src/pages/ReviewDetail.tsx
+++ b/frontend/src/pages/ReviewDetail.tsx
@@ -299,7 +299,7 @@ export default function ReviewDetail() {
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-4 pt-2">
-              <ReviewStatus initialStatus={review.status} />
+              <ReviewStatus reviewId={review.id} initialStatus={review.status} />
               <div className="flex items-center gap-2 px-3 py-1.5 rounded-xl border" style={{ backgroundColor: "var(--bg-tertiary)", borderColor: "var(--border)" }}>
                 <span className="text-xs font-bold uppercase tracking-wider" style={{ color: "var(--text-muted)" }}>Risk Score</span>
                 <span className="text-sm font-bold" style={{ color: riskColor(review.risk_score) }}>


### PR DESCRIPTION
- Add realtime/auth.py with JwtQueryAuthMiddleware that reads ?token= from WebSocket URL, validates via rest_framework_simplejwt, and sets scope[user]
- Update devmind/asgi.py to wrap AuthMiddlewareStack with JwtQueryAuthMiddleware
- Fix pre-existing AllowedOriginsOriginValidator → AllowedHostsOriginValidator (channels 4.x rename)