### PR TITLE
fix: repair end-to-end AI review pipeline

### DIFF
--- a/backend/django/apps/repositories/tasks.py
+++ b/backend/django/apps/repositories/tasks.py
@@ -290,7 +290,8 @@ def trigger_review_task(
             pr_title=pr_title,
             head_sha=head_sha,
             base_sha=base_sha or head_sha,
-            diff_url=diff_url or f"{repo.html_url}/pull/{pr_number}",
+            diff_url=diff_url
+            or f"https://api.github.com/repos/{repo.full_name}/pulls/{pr_number}",
             status="pending",
         )
 

--- a/backend/django/apps/reviews/services/github_poster.py
+++ b/backend/django/apps/reviews/services/github_poster.py
@@ -9,9 +9,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import requests
-from django.conf import settings
-
-from apps.repositories.services import GitHubService
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +111,35 @@ class GitHubPoster:
             )
             return []
 
-        grouped = self.group_by_file(comments)
+        # Split: inline comments need a valid line number (> 0).
+        # Comments with line_number <= 0 (LLM returned 0 or omitted it) would
+        # cause GitHub to return 422 for the entire batch, silently dropping all
+        # comments. Fold those into the review body summary instead.
+        inline = [c for c in comments if (c.get("line_number") or 0) > 0]
+        body_only = [c for c in comments if (c.get("line_number") or 0) <= 0]
+
+        if body_only:
+            extra_lines = [summary] if summary else []
+            for c in body_only:
+                emoji = self._severity_emoji(c.get("severity", "info"))
+                file_ref = c.get("file_path", "")
+                extra_lines.append(f"\n**{file_ref}** — {emoji} {c.get('body', '')}")
+            summary = "\n".join(extra_lines)
+
+        if not inline:
+            # No inline comments — post a body-only review to deliver the summary.
+            if summary:
+                status = self._post_review(
+                    repo_full_name=repo_full_name,
+                    pr_number=pr_number,
+                    head_sha=head_sha,
+                    comments=[],
+                    summary=summary,
+                )
+                return [status]
+            return []
+
+        grouped = self.group_by_file(inline)
         status_codes = []
 
         batches = self._create_batches(grouped)
@@ -242,6 +267,7 @@ class GitHubPoster:
                 {
                     "path": c.path,
                     "line": c.line,
+                    "side": "RIGHT",
                     "body": c.body,
                 }
                 for c in comments
@@ -250,6 +276,25 @@ class GitHubPoster:
 
         url = f"{GITHUB_API_BASE}/repos/{repo_full_name}/pulls/{pr_number}/reviews"
         response = self._session.post(url, json=payload, timeout=30.0)
+
+        if response.status_code == 422 and payload["comments"]:
+            # Inline comments have invalid line numbers (LLM hallucinated lines
+            # outside the diff). Retry as a body-only review so comments aren't lost.
+            logger.warning(
+                "github_poster.inline_failed_retrying_body_only repo=%s pr=%d",
+                repo_full_name,
+                pr_number,
+            )
+            fallback_lines = [payload["body"]] if payload["body"] else []
+            for c in comments:
+                fallback_lines.append(f"**`{c.path}` line {c.line}** — {c.body}")
+            fallback_payload = {
+                "commit_id": head_sha,
+                "event": "COMMENT",
+                "body": "\n\n".join(fallback_lines),
+                "comments": [],
+            }
+            response = self._session.post(url, json=fallback_payload, timeout=30.0)
 
         if response.status_code not in (200, 201):
             logger.error(

--- a/backend/django/apps/reviews/services/orchestrator.py
+++ b/backend/django/apps/reviews/services/orchestrator.py
@@ -203,6 +203,14 @@ class ReviewOrchestrator:
                         "both Django .env and FastAPI .env."
                     )
 
+                if response.status_code == 429:
+                    # LLM providers are rate limited — fast retries won't help,
+                    # the rate limit window is ~60s. Raise immediately so Celery's
+                    # retry (default_retry_delay=60) handles the backoff correctly.
+                    raise FastAPIError(
+                        "LLM providers rate limited (429). Celery will retry in 60s."
+                    )
+
                 if response.status_code == 503:
                     logger.warning(
                         "orchestrator.fastapi.503 attempt=%d/%d review_id=%d",

--- a/backend/django/apps/reviews/tasks.py
+++ b/backend/django/apps/reviews/tasks.py
@@ -39,6 +39,18 @@ def trigger_review_task(self, review_id: int):
 
     except Exception as e:
         logger.error("review.failed review_id=%d error=%s", review_id, str(e))
+        # Reset to pending so the orchestrator's state guard allows the retry to run.
+        # Only reset when retries remain — on the final attempt leave it as "failed"
+        # so the review doesn't get stuck in "pending" with no active task.
+        if self.request.retries < self.max_retries:
+            try:
+                from apps.reviews.models import Review
+
+                Review.objects.filter(pk=review_id, status="failed").update(
+                    status="pending"
+                )
+            except Exception:
+                pass
         raise self.retry(exc=e)
 
 

--- a/backend/django/devmind/settings/base.py
+++ b/backend/django/devmind/settings/base.py
@@ -184,6 +184,9 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "UTC"
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_RESULT_EXTENDED = True
+# Without this, tasks with no explicit queue go to the built-in "celery" queue,
+# but the worker listens to "default,review,notifications" — not "celery".
+CELERY_TASK_DEFAULT_QUEUE = "default"
 
 # Kafka
 KAFKA_BOOTSTRAP_SERVERS = env("KAFKA_BOOTSTRAP_SERVERS", default="")
@@ -291,6 +294,10 @@ CELERY_TASK_ROUTES = {
     "repositories.install_webhook": {"queue": "default"},
     "repositories.remove_webhook": {"queue": "default"},
     "repositories.trigger_review": {"queue": "review"},
+    "apps.reviews.tasks.trigger_review_task": {"queue": "default"},
+    "apps.reviews.tasks.post_github_comments_task": {"queue": "default"},
+    "apps.reviews.tasks.full_repo_scan_task": {"queue": "default"},
+    "apps.reviews.tasks.cleanup_old_reviews": {"queue": "default"},
     "organizations.send_invite_email_task": {"queue": "default"},
     "organizations.sync_org_members_task": {"queue": "default"},
 }

--- a/backend/fastapi/routers/review.py
+++ b/backend/fastapi/routers/review.py
@@ -193,10 +193,10 @@ async def analyze_review(
     except AllProvidersDownError:
         review_errors_total.labels(error_type="llm_unavailable").inc()
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail={
-                "error": "llm_unavailable",
-                "message": "All LLM providers are temporarily unavailable",
+                "error": "llm_rate_limited",
+                "message": "All LLM providers are rate limited. Retry in 60s.",
             },
         )
     except Exception as e:


### PR DESCRIPTION
Fix a chain of issues preventing webhook-triggered reviews from completing and posting comments to GitHub PRs.

- Orchestrator: handle FastAPI 429 (LLM rate limited) as an immediate raise instead of retrying 3x in 15s — lets Celery's 60s retry delay handle the rate-limit window correctly instead of hammering all providers

- FastAPI review router: return 429 (not 503) for AllProvidersDownError so the orchestrator can distinguish rate limiting from a true outage

- Review task: reset status to pending before Celery retry so the orchestrator state guard (pending → processing) allows the next attempt to run; leave as failed on the final attempt

- GitHub poster: fold comments with line_number <= 0 into the review body instead of sending them as inline comments (prevents GitHub 422 rejecting the entire batch); add side: RIGHT to inline comment payloads; add 422 fallback that retries the full comment set as a body-only review when LLM-generated line numbers fall outside the diff

- Settings: add CELERY_TASK_DEFAULT_QUEUE = default so tasks without an explicit queue don't go to the built-in celery queue (which no worker listens to); register reviews task routes explicitly

- Repositories task: fix diff_url fallback to use the GitHub API URL instead of the HTML URL