### PR TITLE
feat: implement tickets 11, 14, 15 — diff storage, Flower, deep healt…

### DIFF
--- a/backend/django/apps/reviews/migrations/0004_reviewrun_diff_text.py
+++ b/backend/django/apps/reviews/migrations/0004_reviewrun_diff_text.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reviews", "0003_review_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="reviewrun",
+            name="diff_text",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text="Raw unified diff stored at review time to avoid re-fetching from GitHub.",
+            ),
+        ),
+    ]

--- a/backend/django/apps/reviews/models.py
+++ b/backend/django/apps/reviews/models.py
@@ -190,6 +190,11 @@ class ReviewRun(models.Model):
         default=0,
         help_text="LLM response time in milliseconds.",
     )
+    diff_text = models.TextField(
+        blank=True,
+        default="",
+        help_text="Raw unified diff stored at review time to avoid re-fetching from GitHub.",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/backend/django/apps/reviews/serializers.py
+++ b/backend/django/apps/reviews/serializers.py
@@ -33,6 +33,7 @@ class ReviewRunSerializer(serializers.ModelSerializer):
             "prompt_tokens",
             "completion_tokens",
             "latency_ms",
+            "diff_text",
             "created_at",
         ]
         read_only_fields = fields

--- a/backend/django/apps/reviews/services/orchestrator.py
+++ b/backend/django/apps/reviews/services/orchestrator.py
@@ -101,7 +101,7 @@ class ReviewOrchestrator:
         try:
             diff = self._fetch_diff()
             result = self._call_fastapi(diff)
-            self._save_results(result)
+            self._save_results(result, diff)
 
             self.review.status = "completed"
             self.review.risk_score = result.risk_score
@@ -233,7 +233,7 @@ class ReviewOrchestrator:
         )
 
     @transaction.atomic
-    def _save_results(self, result: ReviewResult) -> None:
+    def _save_results(self, result: ReviewResult, diff: str = "") -> None:
         """
         Save ReviewRun and ReviewComment records.
 
@@ -241,15 +241,16 @@ class ReviewOrchestrator:
                       mapped to safe defaults instead of storing invalid data.
         FIX (Bug 2b): populate prompt_tokens, completion_tokens,
                       agent_iterations on ReviewRun.
+        TICKET-11: store diff so the frontend never needs to re-fetch it.
         """
         ReviewRun.objects.create(
             review=self.review,
-            # FIX 2b: these were always 0 before
             agent_iterations=result.agent_iterations,
             model_used=result.model_used,
             prompt_tokens=result.prompt_tokens,
             completion_tokens=result.completion_tokens,
             latency_ms=result.latency_ms,
+            diff_text=diff,
         )
 
         for comment_data in result.comments:

--- a/backend/fastapi/routers/health.py
+++ b/backend/fastapi/routers/health.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
 from core.database import AsyncSessionLocal
@@ -9,16 +10,39 @@ router = APIRouter(tags=["health"])
 
 @router.get("/health")
 async def health_check():
+    checks: dict[str, str] = {}
+
+    # Database + pgvector extension
     try:
         async with AsyncSessionLocal() as session:
             await session.execute(text("SELECT 1"))
-        db_status = "ok"
-    except Exception as e:
-        db_status = f"error: {e}"
+            row = await session.execute(
+                text("SELECT extversion FROM pg_extension WHERE extname='vector'")
+            )
+            pgvector_version = row.scalar_one_or_none()
+            checks["database"] = "ok"
+            checks["pgvector"] = (
+                f"ok ({pgvector_version})"
+                if pgvector_version
+                else "error: extension not installed"
+            )
+    except Exception as exc:
+        checks["database"] = f"error: {exc}"
+        checks["pgvector"] = "unknown"
 
-    llm_status = {}
+    # LLM providers — informational only, failover chain handles degradation
     for config in MODEL_CHAIN:
         provider, is_healthy = await check_provider_health(config)
-        llm_status[provider] = "ok" if is_healthy else "error"
+        checks[f"llm_{provider}"] = "ok" if is_healthy else "unreachable"
 
-    return {"status": "ok", "db": db_status, "llm": llm_status}
+    # DB down or pgvector missing → 503 so ECS/k8s stops routing traffic here
+    critical_ok = checks.get("database") == "ok" and checks.get(
+        "pgvector", ""
+    ).startswith("ok")
+    overall = "ok" if critical_ok else "degraded"
+    status_code = 200 if critical_ok else 503
+
+    return JSONResponse(
+        {"status": overall, "checks": checks},
+        status_code=status_code,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,16 @@ services:
       - redis
       - postgres
 
+  flower:
+    image: mher/flower:2.0
+    command: celery --broker=redis://redis:6379/0 flower --port=5555
+    ports:
+      - "5555:5555"
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+    depends_on:
+      - redis
+    restart: unless-stopped
 
   nginx:
     build: ./nginx

--- a/frontend/src/pages/ReviewDetail.tsx
+++ b/frontend/src/pages/ReviewDetail.tsx
@@ -33,6 +33,7 @@ interface ReviewDetail {
   created_at: string;
   completed_at: string | null;
   comments: ReviewComment[];
+  run?: { diff_text?: string };
 }
 
 function normalizePath(path: string): string {
@@ -159,34 +160,42 @@ export default function ReviewDetail() {
     try {
       let diffText = "";
 
-      if (reviewData.diff_url) {
-        try {
-          const direct = await fetch(reviewData.diff_url);
-          if (direct.ok) {
-            diffText = await direct.text();
-          }
-        } catch {
-          // ignore direct fetch failures and fallback to GitHub API with token
-        }
+      // Prefer diff stored at review time — zero extra API calls
+      if (reviewData.run?.diff_text && reviewData.run.diff_text.includes("diff --git")) {
+        diffText = reviewData.run.diff_text;
       }
 
-      if (!diffText || !diffText.includes("diff --git")) {
-        const tokenData = await authApi.getGithubToken();
-        const ghRes = await fetch(
-          `https://api.github.com/repos/${reviewData.repository_name}/pulls/${reviewData.pr_number}`,
-          {
-            headers: {
-              Accept: "application/vnd.github.v3.diff",
-              Authorization: `Bearer ${tokenData.access_token}`,
-              "X-GitHub-Api-Version": "2022-11-28",
-            },
+      // Fallback: fetch from GitHub if the stored diff is missing (older reviews)
+      if (!diffText) {
+        if (reviewData.diff_url) {
+          try {
+            const direct = await fetch(reviewData.diff_url);
+            if (direct.ok) {
+              diffText = await direct.text();
+            }
+          } catch {
+            // ignore and fall through to authenticated GitHub API call
           }
-        );
-
-        if (!ghRes.ok) {
-          throw new Error(`GitHub API returned ${ghRes.status}`);
         }
-        diffText = await ghRes.text();
+
+        if (!diffText || !diffText.includes("diff --git")) {
+          const tokenData = await authApi.getGithubToken();
+          const ghRes = await fetch(
+            `https://api.github.com/repos/${reviewData.repository_name}/pulls/${reviewData.pr_number}`,
+            {
+              headers: {
+                Accept: "application/vnd.github.v3.diff",
+                Authorization: `Bearer ${tokenData.access_token}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+            }
+          );
+
+          if (!ghRes.ok) {
+            throw new Error(`GitHub API returned ${ghRes.status}`);
+          }
+          diffText = await ghRes.text();
+        }
       }
 
       const parsed = parseUnifiedDiff(diffText);


### PR DESCRIPTION
…h check

TICKET-11: store PR diff in ReviewRun.diff_text at review time so the frontend never re-fetches it from GitHub on every page load. Falls back to the GitHub API only for reviews created before this change.
- Add diff_text TextField to ReviewRun model + migration 0004
- Pass diff through orchestrator._save_results(result, diff)
- Expose diff_text in ReviewRunSerializer
- ReviewDetail.tsx uses run.diff_text first; GitHub API is last resort

TICKET-14: add Celery Flower service to docker-compose for real-time task visibility at http://localhost:5555

TICKET-15: replace always-200 health endpoint with a deep check that queries pg_extension for the vector extension and returns HTTP 503 when the database or pgvector is unavailable, so load balancers can stop routing traffic to a degraded instance